### PR TITLE
Change global Font to FontEx

### DIFF
--- a/Source/Config.cpp
+++ b/Source/Config.cpp
@@ -99,7 +99,7 @@ static void from_json(const json& j, ColorToggleRounding& ctr)
     read(j, "Rounding", ctr.rounding);
 }
 
-static void from_json(const json& j, Font& f)
+static void from_json(const json& j, FontEx& f)
 {
     read<value_t::string>(j, "Name", f.name);
 
@@ -325,7 +325,7 @@ static void to_json(json& j, const ColorToggleThicknessRounding& o, const ColorT
     WRITE("Thickness", thickness);
 }
 
-static void to_json(json& j, const Font& o, const Font& dummy = {})
+static void to_json(json& j, const FontEx& o, const FontEx& dummy = {})
 {
     WRITE("Name", name);
 }

--- a/Source/ConfigStructs.h
+++ b/Source/ConfigStructs.h
@@ -61,7 +61,7 @@ struct ColorToggleThicknessRounding : ColorToggleRounding {
     float thickness = 1.0f;
 };
 
-struct Font {
+struct FontEx {
     int index = 0; // do not save
     std::string name;
 };
@@ -91,7 +91,7 @@ struct Box : ColorToggleRounding {
 
 struct Shared {
     bool enabled = false;
-    Font font;
+    FontEx font;
     Snapline snapline;
     Box box;
     ColorToggle name;


### PR DESCRIPTION
If comdef.h is in use on Windows, it already has Font, see https://github.com/icestudent/vc-19-changes/blob/master/comdef.h#L492
original pull request https://github.com/danielkrupinski/Osiris/pull/3659